### PR TITLE
Dev speedindex

### DIFF
--- a/Masquerade.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Masquerade.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -115,7 +115,7 @@ class Plugin(indigo.PluginBase):
         elif valFormat == "Octal":
             scaledString = oct(scaled)
         else:
-            self.logger.error(f"scaleBaseToMasq: Unknown masqValueFormat = {valFormat}")
+            self.logger.error(f"scaleMasqToBase: Unknown masqValueFormat = {valFormat}")
             return None
 
         self.logger.debug(


### PR DESCRIPTION
Some enhancements for the speed-control flavor of masquerade devices. These changes make my GE/Jasco fan much more of a team player.

(A notable bug this fixed was that "Send status request" on the masquerade device would set the speed to zero, because actionControlSpeedControl() was receiving a status request action but unconditionally treating all actions as setting the speed index, and thus getting an actionValue of zero)